### PR TITLE
Be compatible with Python 3.9

### DIFF
--- a/factorise.py
+++ b/factorise.py
@@ -1,8 +1,7 @@
 #!/usr/bin/python3 -O
 
-from math import sqrt, log2, ceil, floor
+from math import sqrt, log2, ceil, floor, gcd
 import random
-from fractions import gcd
 import sys
 from builtins import ValueError
 


### PR DESCRIPTION
gcd is now part of the math module, rather than the fractions module.

From https://docs.python.org/3/library/fractions.html:
> Changed in version 3.9: The `math.gcd()` function is now used to normalize the numerator and denominator. `math.gcd()` always return a `int` type.
> Previously, the GCD type depended on numerator and denominator.